### PR TITLE
Add helpers to create retryable errors

### DIFF
--- a/retryable.go
+++ b/retryable.go
@@ -1,6 +1,10 @@
 package errorutil
 
-import "net/http"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
 
 // Retryabler defines an error that may be temporary. A function returning a retryable error should be executed again.
 type Retryabler interface {
@@ -55,6 +59,17 @@ func RetryableError(err error) error {
 		return nil
 	}
 	return &retryableError{err: err}
+}
+
+// NewRetryableError returns a retryable error that formats as the given text.
+func NewRetryableError(text string) error {
+	return RetryableError(errors.New(text))
+}
+
+// NewRetryableErrorf formats according to a format specifier and returns the string
+// as a value that satisfies a retryable error.
+func NewRetryableErrorf(format string, args ...interface{}) error {
+	return RetryableError(fmt.Errorf(format, args...))
 }
 
 type retryableError struct {

--- a/retryable_test.go
+++ b/retryable_test.go
@@ -106,3 +106,33 @@ func ExampleIsNotRetryable() {
 	err = RetryableError(err)
 	IsNotRetryable(err) // will return false
 }
+
+func TestNewRetryableError(t *testing.T) {
+	err := NewRetryableError("retryable error")
+	if IsNotRetryable(err) {
+		t.Errorf("NewRetryableError must return a retryable error")
+	}
+	if err.Error() != "retryable error" {
+		t.Errorf("NewRetryableError: expected :%s, got %s", "test", err.Error())
+	}
+}
+
+func ExampleNewRetryableError() {
+	err := NewRetryableError("test")
+	IsRetryable(err) // will return true
+}
+
+func TestNewRetryableErrorf(t *testing.T) {
+	err := NewRetryableErrorf("retryable error %s", "formatted")
+	if IsNotRetryable(err) {
+		t.Errorf("NewRetryableErrorf must return a retryable error")
+	}
+	if err.Error() != "retryable error formatted" {
+		t.Errorf("NewRetryableErrorf: expected :%s, got %s", "retryable error formatted", err.Error())
+	}
+}
+
+func ExampleNewRetryableErrorf() {
+	err := NewRetryableErrorf("Unable to read data for device %d", 70)
+	IsRetryable(err) // will return true
+}


### PR DESCRIPTION
This PR adds two new helpers to create retryable errors : 

- `NewRetryableError(text string)` : creates a new retryable error with the given string - just like `errors.New`
- `NewRetryableErrorf(format string, args ...interface{})` : creates a new retryable errors with the given format and arguments - just like `fmt.Errorf`